### PR TITLE
Fixes to supress some error messages/warnings.

### DIFF
--- a/src/BlocklyToolbox.jsx
+++ b/src/BlocklyToolbox.jsx
@@ -76,13 +76,13 @@ class BlocklyToolbox extends React.Component {
   render = () => {
     if (this.props.categories) {
       return (
-        <xml style={{ display: 'none' }} ref={(node) => { this.rootNode = node; }}>
+        <xml style={{ display: 'none' }} is="div" ref={(node) => { this.rootNode = node; }}>
           {this.renderCategories(this.props.categories.map(this.processCategory))}
         </xml>
       );
     }
     return (
-      <xml style={{ display: 'none' }} ref={(node) => { this.rootNode = node; }}>
+      <xml style={{ display: 'none' }} is="div" ref={(node) => { this.rootNode = node; }}>
         {this.props.blocks.map(BlocklyToolboxBlock.renderBlock)}
       </xml>
     );

--- a/src/BlocklyToolboxBlock.jsx
+++ b/src/BlocklyToolboxBlock.jsx
@@ -58,7 +58,7 @@ class BlocklyToolboxBlock extends React.PureComponent {
 
     if (this.props.fields) {
       fields = this.props.fields.map((fieldValue, fieldName, i) => (
-        <field name={fieldName} key={`field_${fieldName}_${i}`}>
+        <field name={fieldName} key={`field_${fieldName}_${i}`} is="div">
           {fieldValue}
         </field>
       )).valueSeq();
@@ -66,7 +66,7 @@ class BlocklyToolboxBlock extends React.PureComponent {
 
     if (this.props.values) {
       values = this.props.values.map((valueBlock, valueName, i) => (
-        <value name={valueName} key={`value_${valueName}_${i}`}>
+        <value name={valueName} key={`value_${valueName}_${i}`} is="div">
           {BlocklyToolboxBlock.renderBlock(valueBlock)}
         </value>
       )).valueSeq();
@@ -74,7 +74,8 @@ class BlocklyToolboxBlock extends React.PureComponent {
 
     if (this.props.statements) {
       statements = this.props.statements.map((statementBlock, statementName, i) => (
-        <statement name={statementName} key={`statement_${statementName}_${i}`}>
+        <statement name={statementName} key={`statement_${statementName}_${i}`}
+          is="div">
           {BlocklyToolboxBlock.renderBlock(statementBlock)}
         </statement>
       )).valueSeq();
@@ -86,13 +87,14 @@ class BlocklyToolboxBlock extends React.PureComponent {
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: this.props.mutation.get('innerContent') }}
           ref={(mutationElement) => { this.mutationElement = mutationElement; }}
+          is="div"
         />
       ));
     }
 
     if (this.props.next) {
       nextBlock = ((
-        <next>
+        <next is="div">
           {BlocklyToolboxBlock.renderBlock(this.props.next)}
         </next>
       ));
@@ -100,7 +102,7 @@ class BlocklyToolboxBlock extends React.PureComponent {
 
     if (this.props.shadow) {
       return (
-        <shadow type={this.props.type}>
+        <shadow type={this.props.type} is="div">
           {mutation}
           {fields}
           {values}
@@ -111,7 +113,7 @@ class BlocklyToolboxBlock extends React.PureComponent {
     }
 
     return (
-      <block type={this.props.type}>
+      <block type={this.props.type} is="div">
         {mutation}
         {fields}
         {values}

--- a/src/BlocklyToolboxCategory.jsx
+++ b/src/BlocklyToolboxCategory.jsx
@@ -53,7 +53,8 @@ class BlocklyToolboxCategory extends React.PureComponent {
     const buttons = (this.props.button || []).map(BlocklyToolboxButton.renderButton);
 
     return (
-      <category name={this.props.name} custom={this.props.custom} colour={this.props.colour} expanded={this.props.expanded}>
+      <category name={this.props.name} custom={this.props.custom}
+        colour={this.props.colour} expanded={this.props.expanded} is="div">
         {buttons}
         {blocks}
         {subcategories}

--- a/src/BlocklyWorkspace.jsx
+++ b/src/BlocklyWorkspace.jsx
@@ -130,13 +130,15 @@ class BlocklyWorkspace extends React.Component {
     let dummyToolboxContent;
     if (this.props.toolboxMode === 'CATEGORIES') {
       dummyToolboxContent = (
-        <category name="Dummy toolbox" />
+        <category name="Dummy toolbox" colour=''/>
       );
     }
 
     return (
       <div className={this.props.wrapperDivClassName}>
-        <xml style={{ display: 'none' }} ref={(dummyToolbox) => { this.dummyToolbox = dummyToolbox; }}>
+        <xml style={{ display: 'none' }}
+          ref={(dummyToolbox) => { this.dummyToolbox = dummyToolbox; }}
+          is="div">
           {dummyToolboxContent}
         </xml>
         <div


### PR DESCRIPTION
Handling the previous issue flagged by @eordano where xml elements were throwing errors. This should also play nicely with Blockly since the tags are the same.

I also tossed the colour attribute onto the "Dummy Toolbox" to get rid of the warning that was throwing.