### PR TITLE
project entry and webpack improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 6.0.0 - September 15, 2020
+* Update webpack files to support default export of the component , seperate the dev example from the package
+
 # Version 5.3.0 - August 12, 2020
 
 * Upgrade to Babel 7, fix configuration to actually transpile to ES5

--- a/README.md
+++ b/README.md
@@ -25,7 +25,19 @@ To add react-blockly to a React app that uses yarn, run:
 yarn add react-blockly
 ```
 
-Once you've done either of these, you should be able to `import ReactBlockly from 'react-blockly';` in your code and use ReactBlockly as a component.
+## How to use
+
+write `import ReactBlockly from 'react-blockly';` in your code and use ReactBlockly as a component.
+
+You could also import one of these component:
+  ```
+  BlocklyEditor,
+  BlocklyToolbox,
+  BlocklyToolboxBlock,
+  BlocklyToolboxCategory,
+  BlocklyWorkspace```
+using `import 'BlocklyToolbox' from 'react-blockly'`(or another component name)
+
 
 ## Developer setup for working on this package
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ You could also import one of these component:
   BlocklyToolbox,
   BlocklyToolboxBlock,
   BlocklyToolboxCategory,
-  BlocklyWorkspace```
-using `import 'BlocklyToolbox' from 'react-blockly'`(or another component name)
+  BlocklyWorkspace
+  ```
+using `import { BlocklyToolbox } from 'react-blockly'`(or another component name)
 
 
 ## Developer setup for working on this package

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "react-blockly",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "A React wrapper for the Blockly visual programming editor",
-  "main": "dist-modules",
+  "main": "dist/react-blockly.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",
     "lint": "eslint --ext .js,.jsx src",
     "lint:fix": "eslint --fix --ext .js,.jsx src",
-    "start": "webpack-dev-server --config webpack.config.js",
+    "start": "webpack-dev-server --config webpack.config.test.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublishOnly": "babel ./src --out-dir ./dist-modules",
-    "prepublish:watch": "babel ./src --watch --out-dir ./dist-modules",
+    "prepublishOnly": "babel ./src --out-dir ./dist",
+    "prepublish:watch": "babel ./src --watch --out-dir ./dist",
     "prepare": "npm run prepublishOnly"
   },
   "author": "Nat Budin <natbudin@gmail.com>",

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore.js"></script>
-  <script src="react-blockly-component.js"></script>
+  <script src="react-blockly.js"></script>
 
   <style type="text/css">
   .fill-height {

--- a/src/dev-index.jsx
+++ b/src/dev-index.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Blockly from 'blockly';
 
-import ReactBlocklyComponent from './index';
+import ReactBlockly from './index';
 import ConfigFiles from './initContent/content';
 import parseWorkspaceXml from './BlocklyHelper';
 
@@ -21,7 +21,6 @@ class TestEditor extends React.Component {
       this.setState({
         toolboxCategories: this.state.toolboxCategories.concat([
           {
-            name: 'Text2',
             blocks: [
               { type: 'text' },
               {
@@ -75,7 +74,7 @@ class TestEditor extends React.Component {
   }
 
   render = () => (
-    <ReactBlocklyComponent.BlocklyEditor
+    <ReactBlockly
       toolboxCategories={this.state.toolboxCategories}
       workspaceConfiguration={{
         grid: {

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,10 @@ import BlocklyToolboxBlock from './BlocklyToolboxBlock';
 import BlocklyToolboxCategory from './BlocklyToolboxCategory';
 import BlocklyWorkspace from './BlocklyWorkspace';
 
-const ReactBlocklyComponent = {
-  BlocklyEditor,
-  BlocklyToolbox,
-  BlocklyToolboxBlock,
-  BlocklyToolboxCategory,
-  BlocklyWorkspace,
+export {
+  BlocklyEditor, BlocklyToolbox, BlocklyToolboxBlock,
+  BlocklyToolboxCategory, BlocklyWorkspace,
 };
 
-export default ReactBlocklyComponent;
+
+export default BlocklyEditor;

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 module.exports = {
   entry: [
-    './src/index.js',
+    './src/dev-index.jsx',
   ],
   output: {
     path: path.resolve(__dirname, 'dist'),
@@ -29,5 +29,9 @@ module.exports = {
   ],
   resolve: {
     extensions: ['.js', '.jsx'],
+  },
+  devServer: {
+    contentBase: './public',
+    filename: 'react-blockly.js',
   },
 };


### PR DESCRIPTION
Hi, I change a few things:
-change the entry point in webpack to `'index.js'` instead of the demo.
-change the output to be in `dist` instead `dist-modules` like it's work in other common projects.\
-change react-blockly-component to just recat-blockly.
-add another webpack config for the test app to separate between the package and the demo app ... I think it's better.
-change library target to `umd` (https://stackoverflow.com/questions/51233240/how-are-umd-and-commonjs-cjs-package--folders-different-and-which-should-i-use)
-Add some fixed to the readme and to the log..

I will glad to hear your opinion and what do you think?

I test it locally with 'yarn link' and it looks fine! the only thing I didn't test is the `prepublishOnly` and` `prepublish:watch`