### PR TITLE
Convert BlockyWorkspace to a Functional Component

### DIFF
--- a/src/BlocklyEditor.jsx
+++ b/src/BlocklyEditor.jsx
@@ -98,7 +98,14 @@ class BlocklyEditor extends React.Component {
   }
 
   workspaceDidChange = (workspace) => {
+    const previousWorkspace = this.workspace;
     this.workspace = workspace;
+
+    if (previousWorkspace !== workspace) {
+      // Make sure the new Blockly's workspace has it's toolbox updated.
+      this.toolboxDidUpdate();
+    }
+
     if (this.props.workspaceDidChange) {
       this.props.workspaceDidChange(workspace);
     }

--- a/src/BlocklyEditor.jsx
+++ b/src/BlocklyEditor.jsx
@@ -102,7 +102,7 @@ class BlocklyEditor extends React.Component {
     this.workspace = workspace;
 
     if (previousWorkspace !== workspace) {
-      // Make sure the new Blockly's workspace has it's toolbox updated.
+      // Make sure the new Blockly workspace has it's toolbox updated.
       this.toolboxDidUpdate();
     }
 

--- a/src/BlocklyEditor.jsx
+++ b/src/BlocklyEditor.jsx
@@ -4,6 +4,7 @@ import Immutable from 'immutable';
 
 import BlocklyToolbox from './BlocklyToolbox';
 import BlocklyWorkspace from './BlocklyWorkspace';
+import {importFromXml} from './BlocklyHelper'
 
 const BlockPropType = PropTypes.shape({
   type: PropTypes.string,
@@ -85,8 +86,8 @@ class BlocklyEditor extends React.Component {
 
   toolboxDidUpdate = () => {
     const workspaceConfiguration = this.props.workspaceConfiguration || {};
-    if (this.workspace && !workspaceConfiguration.readOnly) {
-      this.workspace.toolboxDidUpdate(this.toolbox.getRootNode());
+    if (this.workspace && this.toolbox && !workspaceConfiguration.readOnly) {
+      this.workspace.updateToolbox(this.toolbox.getRootNode())
     }
   }
 
@@ -97,15 +98,18 @@ class BlocklyEditor extends React.Component {
   }
 
   workspaceDidChange = (workspace) => {
+    this.workspace = workspace;
     if (this.props.workspaceDidChange) {
       this.props.workspaceDidChange(workspace);
     }
   }
 
-  importFromXml = (xml) => this.workspace.importFromXml(xml)
+  importFromXml = (xml) => {
+    return importFromXml(xml, this.workspace, this.props.onImportXmlError);
+  }
 
   resize = () => {
-    this.workspace.resize();
+    Blockly.svgResize(this.workspace);
   }
 
   render = () => {
@@ -126,7 +130,6 @@ class BlocklyEditor extends React.Component {
           ref={(toolbox) => { this.toolbox = toolbox; }}
         />
         <BlocklyWorkspace
-          ref={(workspace) => { this.workspace = workspace; }}
           initialXml={this.props.initialXml}
           onImportXmlError={this.props.onImportXmlError}
           toolboxMode={toolboxMode}

--- a/src/BlocklyHelper.jsx
+++ b/src/BlocklyHelper.jsx
@@ -1,3 +1,5 @@
+import Blockly from 'blockly';
+
 /**
  * @param {string} xml
  */

--- a/src/BlocklyHelper.jsx
+++ b/src/BlocklyHelper.jsx
@@ -165,3 +165,15 @@ function parseObject(obj) {
 
   return res;
 }
+
+export function importFromXml(xml, workspace, onImportXmlError) {
+  try {
+      Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+      return true;
+    } catch (e) {
+      if (onImportXmlError) {
+        onImportXmlError(e);
+      }
+      return false;
+    }
+};

--- a/src/BlocklyWorkspace.jsx
+++ b/src/BlocklyWorkspace.jsx
@@ -77,6 +77,7 @@ function BlocklyWorkspace(props) {
       },
     );
     setWorkspace(newWorkspace);
+    handleWorkspaceChanged(newWorkspace, props.workspaceDidChange);
 
     if (xml) {
       if (importFromXml(xml, newWorkspace, props.onImportXmlError)) {

--- a/src/BlocklyWorkspace.jsx
+++ b/src/BlocklyWorkspace.jsx
@@ -2,152 +2,168 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Blockly from 'blockly';
 
-function debounce(func, wait) {
-  let timeout;
+import {importFromXml} from './BlocklyHelper'
 
-  return function debouncedFunction(...args) {
-    const context = this;
-    const later = function later() {
+function debounce(func, wait) {
+  let timeout = null;
+  let later = null;
+
+  const debouncedFunction = function(...args) {
+    later = function later() {
       timeout = null;
-      func.apply(context, args);
+      func(...args);
     };
     clearTimeout(timeout);
     timeout = setTimeout(later, wait);
   };
+
+  const cancel = function() {
+    if (timeout !== null) {
+      clearTimeout(timeout) 
+      later();   
+    }
+  };
+
+  return [debouncedFunction, cancel];
 }
 
-class BlocklyWorkspace extends React.Component {
-  static propTypes = {
-    initialXml: PropTypes.string,
-    workspaceConfiguration: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-    wrapperDivClassName: PropTypes.string,
-    xmlDidChange: PropTypes.func,
-    workspaceDidChange: PropTypes.func,
-    onImportXmlError: PropTypes.func,
-    toolboxMode: PropTypes.oneOf(['CATEGORIES', 'BLOCKS']),
-  };
-
-  static defaultProps = {
-    initialXml: null,
-    workspaceConfiguration: null,
-    wrapperDivClassName: null,
-    xmlDidChange: null,
-    workspaceDidChange: null,
-    onImportXmlError: null,
-    toolboxMode: 'BLOCKS',
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      workspace: null,
-      xml: this.props.initialXml,
-    };
+function handleXmlChanged(xml, xmlDidChange) {
+  if (xmlDidChange) {
+    xmlDidChange(xml);
   }
+}
 
-  componentDidMount = () => {
-    // TODO figure out how to use setState here without breaking the toolbox when switching tabs
-    this.state.workspace = Blockly.inject(
-      this.editorDiv,
+function handleWorkspaceChanged(workspace, workspaceDidChange) {
+  if (workspaceDidChange) {
+    workspaceDidChange(workspace);
+  }
+}
+
+const propTypes = {
+  initialXml: PropTypes.string,
+  workspaceConfiguration: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  wrapperDivClassName: PropTypes.string,
+  xmlDidChange: PropTypes.func,
+  workspaceDidChange: PropTypes.func,
+  onImportXmlError: PropTypes.func,
+  toolboxMode: PropTypes.oneOf(['CATEGORIES', 'BLOCKS']),
+}
+
+const defaultProps = {
+  initialXml: null,
+  workspaceConfiguration: null,
+  wrapperDivClassName: null,
+  xmlDidChange: null,
+  workspaceDidChange: null,
+  onImportXmlError: null,
+  toolboxMode: 'BLOCKS',
+}
+
+
+function BlocklyWorkspace(props) {
+  const [workspace, setWorkspace] = React.useState(null);
+  const [xml, setXml] = React.useState(props.initialXml);
+
+  const editorDiv = React.useRef(null);
+  const dummyToolbox = React.useRef(null);
+
+  // Initial mount
+  React.useEffect(() => {
+    const newWorkspace = Blockly.inject(
+      editorDiv.current,
       {
-        ...this.props.workspaceConfiguration,
-        toolbox: this.dummyToolbox,
+        ...props.workspaceConfiguration,
+        toolbox: dummyToolbox.current
       },
     );
+    setWorkspace(newWorkspace);
 
-    if (this.state.xml) {
-      if (this.importFromXml(this.state.xml)) {
-        this.xmlDidChange();
+    if (xml) {
+      if (importFromXml(xml, newWorkspace, props.onImportXmlError)) {
+        handleXmlChanged(xml, props.xmlDidChange);
       } else {
-        this.setState({ xml: null }, this.xmlDidChange);
+        setXml(null);
+        handleXmlChanged(null, props.xmlDidChange);
       }
     }
 
-    this.state.workspace.addChangeListener(this.workspaceDidChange);
+    // Dispose of the workspace when our div ref goes away (Equivalent to didComponentUnmount)
+    return () => {
+      newWorkspace.dispose();
+    };
+  }, [editorDiv]);
 
-    this.state.workspace.addChangeListener(debounce(() => {
-      const newXml = Blockly.Xml.domToText(Blockly.Xml.workspaceToDom(this.state.workspace));
-      if (newXml === this.state.xml) {
+
+  // workspaceDidChange callback
+  React.useEffect(() => {
+    if (workspace === null) {
+      return;
+    }
+
+    const callback = () => {
+      handleWorkspaceChanged(workspace, props.workspaceDidChange);
+    };
+
+    workspace.addChangeListener(callback);
+
+    return () => { workspace.removeChangeListener(callback); };
+  }, [workspace, props.workspaceDidChange]);
+
+
+  // xmlDidChange callback
+  React.useEffect(() => {
+    if (workspace === null) {
+      return;
+    }
+
+    const [callback, cancel] = debounce(() => {
+      const newXml = Blockly.Xml.domToText(Blockly.Xml.workspaceToDom(workspace));
+      if (newXml === xml) {
         return;
       }
 
-      this.setState({ xml: newXml }, this.xmlDidChange);
-    }, 200));
-  }
+      setXml(newXml);
+      handleXmlChanged(newXml, props.xmlDidChange);
+    }, 200);
 
-  componentWillReceiveProps = (newProps) => {
-    if (this.props.initialXml !== newProps.initialXml) {
-      this.setState({ xml: newProps.initialXml });
-    }
-  }
+    workspace.addChangeListener(callback);
 
-  shouldComponentUpdate = () => false
+    return () => { 
+      workspace.removeChangeListener(callback); 
+      cancel();
+    };
+  }, [workspace, xml, props.xmlDidChange]);
 
-  componentWillUnmount = () => {
-    if (this.state.workspace) {
-      this.state.workspace.dispose();
-    }
-  }
+  // Initial Xml Changes
+  React.useEffect(() => {
+    setXml(props.initialXml);
+  }, [props.initialXml]);
 
-  importFromXml = (xml) => {
-    try {
-      Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), this.state.workspace);
-      return true;
-    } catch (e) {
-      if (this.props.onImportXmlError) {
-        this.props.onImportXmlError(e);
-      }
-      return false;
-    }
-  }
-
-  xmlDidChange = () => {
-    if (this.props.xmlDidChange) {
-      this.props.xmlDidChange(this.state.xml);
-    }
-  }
-
-  workspaceDidChange = () => {
-    if (this.props.workspaceDidChange) {
-      this.props.workspaceDidChange(this.state.workspace);
-    }
-  }
-
-  toolboxDidUpdate = (toolboxNode) => {
-    if (toolboxNode && this.state.workspace) {
-      this.state.workspace.updateToolbox(toolboxNode);
-    }
-  }
-
-  resize = () => {
-    Blockly.svgResize(this.state.workspace);
-  }
-
-  render = () => {
-    // We have to fool Blockly into setting up a toolbox with categories initially;
-    // otherwise it will refuse to do so after we inject the real categories into it.
-    let dummyToolboxContent;
-    if (this.props.toolboxMode === 'CATEGORIES') {
-      dummyToolboxContent = (
-        <category name="Dummy toolbox" colour='' is="div"/>
-      );
-    }
-
-    return (
-      <div className={this.props.wrapperDivClassName}>
-        <xml style={{ display: 'none' }}
-          ref={(dummyToolbox) => { this.dummyToolbox = dummyToolbox; }}
-          is="div">
-          {dummyToolboxContent}
-        </xml>
-        <div
-          className={this.props.wrapperDivClassName}
-          ref={(editorDiv) => { this.editorDiv = editorDiv; }}
-        />
-      </div>
+  // We have to fool Blockly into setting up a toolbox with categories initially;
+  // otherwise it will refuse to do so after we inject the real categories into it.
+  let dummyToolboxContent;
+  if (props.toolboxMode === 'CATEGORIES') {
+    dummyToolboxContent = (
+      <category name="Dummy toolbox" colour='' is="div"/>
     );
   }
+
+  return (
+    <div className={props.wrapperDivClassName}>
+      <xml style={{ display: 'none' }}
+        ref={dummyToolbox}
+        is="div">
+        {dummyToolboxContent}
+      </xml>
+      <div
+        className={props.wrapperDivClassName}
+        ref={editorDiv}
+      />
+    </div>
+  );
 }
+
+BlocklyWorkspace.propTypes = propTypes;
+BlocklyWorkspace.defaultProps = defaultProps;
 
 export default BlocklyWorkspace;


### PR DESCRIPTION
Hello! I initially forked this project to try making BlocklyWorkspace's `workspaceDidChange` property fire as soon as the Blockly workspace is created. However, I noticed an odd TODO:
```js
  componentDidMount = () => {
    // TODO figure out how to use setState here without breaking the toolbox when switching tabs
    this.state.workspace = Blockly.inject(
 ```
I noticed that help is wanted converting the components to "Modern" React with functional components, which may help resolve issues like these. I figured that I'd try converting BlocklyWorkspace into a functional component with React hooks

This is a big change, so please feel free to suggest feedback. I tried my best to keep the properties and behavior the same as before, but there are some breaking changes.

I tested this against the example code that is included. No changes were needed in the example code, and it functions the same as before. Would probably be good to test this against some other example code as well before merging.

These changes also seem to fix #32.

### Breaking Changes
* BlocklyWorkspace no longer accepts a `ref` property
* Since functional components don't support methods, the `resize` and `toolboxDidUpdate` methods have been removed.
    * Any functionality provided by these methods that is more than a simple Blockly function has been moved into the BlocklyHelper module.
* workspaceDidChange is now called as soon as the workspace is created with Blockly.Inject
  * I think this change is desirable, as users of this library can now do things with the workspace instance without needing the user to interact with the workspace first.

### Notes
* The 'debounce' function in BlocklyWorkspace now returns a 'cancel' function to make it more convenient for use with the useEffect hook. The returned cancel method calls any pending function immediately instead of later. This way events won't be lost when useEffect is ran again to switch the listeners with updated closure values.