### PR TITLE
[hooks] Make useBlocklyWorkspace return the Blockly workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ using `import { BlocklyToolbox } from 'react-blockly'`(or another component name
 Clone this repository, and then inside it, do:
 
 ```bash
+npm install --global yarn
 yarn install
 yarn run start
 ```

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^15.0 || ^16.0"
+    "react": "^16.8 || ^17.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/src/useBlocklyWorkspace.js
+++ b/src/useBlocklyWorkspace.js
@@ -51,7 +51,7 @@ const useBlocklyWorkspace = ({
     [onWorkspaceChange]
   );
 
-  // Initial mount
+  // Workspace creation
   React.useEffect(() => {
     const newWorkspace = Blockly.inject(ref.current, {
       ...workspaceConfigurationRef.current,
@@ -59,16 +59,25 @@ const useBlocklyWorkspace = ({
     });
     setWorkspace(newWorkspace);
     setDidInitialImport(false); // force a re-import if we recreate the workspace
-    handleWorkspaceChanged(newWorkspace);
-    newWorkspace.addChangeListener(() => {
-      handleWorkspaceChanged(newWorkspace);
-    });
 
     // Dispose of the workspace when our div ref goes away (Equivalent to didComponentUnmount)
     return () => {
       newWorkspace.dispose();
     };
-  }, [handleWorkspaceChanged, ref]);
+  }, [ref]);
+
+  // Workspace change listener
+  React.useEffect(() => {
+    if (workspace == null) {
+      return undefined;
+    }
+    
+    const listener = () => { handleWorkspaceChanged(workspace); };
+    workspace.addChangeListener(listener);
+    return () => {
+      workspace.removeChangeListener(listener);
+    };
+  }, [workspace, handleWorkspaceChanged]);
 
   // xmlDidChange callback
   React.useEffect(() => {
@@ -105,6 +114,8 @@ const useBlocklyWorkspace = ({
       setDidInitialImport(true);
     }
   }, [xml, workspace, didInitialImport, onImportXmlError]);
+
+  return workspace;
 };
 
 export default useBlocklyWorkspace;


### PR DESCRIPTION
Related to the comment I left [here](https://github.com/nbudin/react-blockly/pull/39#issuecomment-809856471), I removed `handleWorkspaceChange` from the effect with the Blockly.Inject call so that a new Blockly workspace isn't created each time `onWorkspaceChange` changes.

To keep things simple, I've reverted back to the original behavior where onWorkspaceChange doesn't get called when the workspace is initially created. Since we now have a hook, the hook return value is probably more convenient for developers to use.

I'm also sneaking in two other changes, feel free to include or omit these specific commits when merging:
* package.json: Setting React 16.8 as the minimum react version, and also support React 17. 
* README.md: Adding `npm install --global yarn` to the developer setup section. Hopefully this eliminates a web search for lazy developers like me who are new to yarn :) 