### PR TITLE
Updated readme: remove yarn run build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,6 @@ yarn run start
 
 webpack-dev-server will start and will be serving a demo of react-blockly, which should automatically refresh if you change the code locally.
 
-## Building the source locally
-
-Clone this repository, and then inside it, do:
-
-```bash
-yarn install
-yarn run build
-```
-
-You'll get a `dist` directory containing the compiled JS file and a source map.
-
 ## Properties
 
 All properties are optional except where otherwise specified.


### PR DESCRIPTION
The "build" task was removed in https://github.com/nbudin/react-blockly/commit/2bc35724a1c3ac5de394df7c41a2dde79f239d1f.

However, if we had a build task, it would be fairly easy to setup a Github Action to automate running the build, and pushing to NPM (using semantic-release for example)