### PR TITLE
fix: all parameters required at UseBlocklyProps

### DIFF
--- a/src/BlocklyWorkspaceProps.ts
+++ b/src/BlocklyWorkspaceProps.ts
@@ -1,21 +1,19 @@
-import Blockly, {WorkspaceSvg} from "blockly";
-import {RefObject} from "react";
+import Blockly, { WorkspaceSvg } from "blockly";
+import { RefObject } from "react";
 
 export interface CommonBlocklyProps {
-    initialXml: string,
-    toolboxConfiguration: Blockly.utils.toolbox.ToolboxDefinition,
-    workspaceConfiguration: Blockly.BlocklyOptions,
-    onWorkspaceChange: (workspace: WorkspaceSvg) => void,
-    onImportXmlError: (error: any) => void,
-    onInject: (newWorkspace: WorkspaceSvg) => void,
-    onDispose: (workspace: WorkspaceSvg) => void
+    initialXml: string;
+    toolboxConfiguration: Blockly.utils.toolbox.ToolboxDefinition;
+    workspaceConfiguration: Blockly.BlocklyOptions;
+    onWorkspaceChange: (workspace: WorkspaceSvg) => void;
+    onImportXmlError?: (error: any) => void;
+    onInject?: (newWorkspace: WorkspaceSvg) => void;
+    onDispose?: (workspace: WorkspaceSvg) => void;
 }
-
 export interface BlocklyWorkspaceProps extends CommonBlocklyProps {
-    className: string,
-    onXmlChange: (xml: string) => void,
+    className?: string;
+    onXmlChange?: (xml: string) => void;
 }
-
 export interface UseBlocklyProps extends CommonBlocklyProps {
     ref: RefObject<Element>;
 }


### PR DESCRIPTION
When using typescript it is very frustrating to declare UseBlocklyProps object as any or to add all the params, even if you don't need to use them (for example: OnInject, OnDispose etc). To solve this problem, I set some of the keys as optional. 