### PR TITLE
fix blocks are injected twice

### DIFF
--- a/src/useBlocklyWorkspace.ts
+++ b/src/useBlocklyWorkspace.ts
@@ -11,6 +11,7 @@ function importFromXml(
   onImportXmlError?: (error: any) => void
 ) {
   try {
+    if (workspace.getAllBlocks(false).length > 0) return; // we won't load blocks again if they are already loaded
     Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
     return true;
   } catch (e) {
@@ -62,7 +63,7 @@ const useBlocklyWorkspace = ({
   }, [onDispose]);
 
   const handleWorkspaceChanged = React.useCallback(
-    (newWorkspace) => {
+    (newWorkspace: WorkspaceSvg) => {
       if (onWorkspaceChange) {
         onWorkspaceChange(newWorkspace);
       }


### PR DESCRIPTION
Using a manual importing (for example ```Blockly.serialization.workspaces.load```) is causing the blocks to be imported twice (by our implementation and by importFromXml function). To solve this problem, we can simply verify if the workspace has blocks and only run if it doesn't.