### PR TITLE
fix: both initialXml and initialJson are required

### DIFF
--- a/src/BlocklyWorkspaceProps.ts
+++ b/src/BlocklyWorkspaceProps.ts
@@ -2,8 +2,8 @@ import Blockly, { WorkspaceSvg } from "blockly";
 import { RefObject } from "react";
 
 export interface CommonBlocklyProps {
-  initialXml: string;
-  initialJson: object;
+  initialXml?: string;
+  initialJson?: object;
   toolboxConfiguration: Blockly.utils.toolbox.ToolboxDefinition;
   workspaceConfiguration: Blockly.BlocklyOptions;
   onWorkspaceChange: (workspace: WorkspaceSvg) => void;

--- a/src/useBlocklyWorkspace.ts
+++ b/src/useBlocklyWorkspace.ts
@@ -56,8 +56,8 @@ const useBlocklyWorkspace = ({
   onImportError = onImportError ?? onImportXmlError
 
   const [workspace, setWorkspace] = React.useState<WorkspaceSvg | null>(null);
-  const [xml, setXml] = React.useState<string | null>(initialXml);
-  const [json, setJson] = React.useState<object | null>(initialJson);
+  const [xml, setXml] = React.useState<string | null>(initialXml || null);
+  const [json, setJson] = React.useState<object | null>(initialJson || null);
   const [didInitialImport, setDidInitialImport] = React.useState(false);
   const [didHandleNewWorkspace, setDidHandleNewWorkspace] =
     React.useState(false);


### PR DESCRIPTION
Both initialXml and initialJson are required, even if you want to use just one of them. To solve this issue I made all both properties optional. If the value isn't provided, they useBlocklyWorkspace will use ```null``` (which doesn't cause any errors).