### PR TITLE
Added compatibility for Blockly 10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Nat Budin <natbudin@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "blockly": ">= 3.20200024.0",
+    "blockly": ">= 10.0.0",
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {

--- a/src/useBlocklyWorkspace.ts
+++ b/src/useBlocklyWorkspace.ts
@@ -12,7 +12,7 @@ function importFromXml(
 ) {
   try {
     if (workspace.getAllBlocks(false).length > 0) return; // we won't load blocks again if they are already loaded
-    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(xml), workspace);
     return true;
   } catch (e) {
     if (onImportError) {


### PR DESCRIPTION
Starting with Blockly 10.0, Blockly.Xml.textToDom is moved to Blockly.utils.xml.textToDom (https://github.com/google/blockly/pull/6818). Due to this change, react-blockly failed to load the xml provided in initialXml. This pull request is a fix to this issue.

This will not work on older versions of blockly, so I've also updated blockly's version in package.json.