### PR TITLE
Optional props on useBlocklyWorkspace

### DIFF
--- a/src/BlocklyWorkspaceProps.ts
+++ b/src/BlocklyWorkspaceProps.ts
@@ -4,9 +4,9 @@ import { RefObject } from "react";
 export interface CommonBlocklyProps {
   initialXml?: string;
   initialJson?: object;
-  toolboxConfiguration: Blockly.utils.toolbox.ToolboxDefinition;
+  toolboxConfiguration?: Blockly.utils.toolbox.ToolboxDefinition;
   workspaceConfiguration: Blockly.BlocklyOptions;
-  onWorkspaceChange: (workspace: WorkspaceSvg) => void;
+  onWorkspaceChange?: (workspace: WorkspaceSvg) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onImportXmlError?: (error: any) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Both toolboxConfiguration and onWorkspaceChange are not required props on the <BlocklyWorkspace /> component; and do not hinder the functionality of useBlocklyWorkspace if they are made optional.

Use case for me is the scenario of not wanting to use a toolbox (and using an external component to manage it); onWorkspaceChange is probably a recommended thing to include, but should not be required.