### PR TITLE
DefaultProps is deprecated - remove from code.

### DIFF
--- a/src/BlocklyWorkspace.tsx
+++ b/src/BlocklyWorkspace.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import useBlocklyWorkspace from "./useBlocklyWorkspace";
-import {BlocklyWorkspaceProps} from "./BlocklyWorkspaceProps";
+import { BlocklyWorkspaceProps } from "./BlocklyWorkspaceProps";
 
 const propTypes = {
   initialXml: PropTypes.string,
@@ -16,21 +16,6 @@ const propTypes = {
   onJsonChange: PropTypes.func,
   onInject: PropTypes.func,
   onDispose: PropTypes.func,
-};
-
-const defaultProps = {
-  initialXml: null,
-  initialJson: null,
-  toolboxConfiguration: null,
-  workspaceConfiguration: null,
-  className: null,
-  onWorkspaceChange: null,
-  onImportXmlError: null,
-  onImportError: null,
-  onXmlChange: null,
-  onJsonChange: null,
-  onInject: null,
-  onDispose: null,
 };
 
 function BlocklyWorkspace({
@@ -81,6 +66,5 @@ function BlocklyWorkspace({
 }
 
 BlocklyWorkspace.propTypes = propTypes;
-BlocklyWorkspace.defaultProps = defaultProps;
 
 export default BlocklyWorkspace;


### PR DESCRIPTION
Hey, 
While using this great package I've seen some warnings in the console suggests that `defaultProps` are deprecated.
I've searched in react repo and it seems it's been there a while - https://github.com/facebook/react/pull/25699
I've found this resource that elaborates more - https://sophiabits.com/blog/stop-using-defaultprops

Bottom line, I've looked in the code and it seems that the `defaultProps` here where all null, my idea was just to delete them.
Hope you'll find it helpful 🙏